### PR TITLE
invoke runner binary

### DIFF
--- a/main.go
+++ b/main.go
@@ -168,7 +168,7 @@ func main() {
 
 	fmt.Printf("DIR:  %s\nUSER: %s\nPASS: %s\nBREF: %s\nBSHA: %s\nREF:  %s\nSHA:  %s\nURL:  %s\n\n", dir, duser, dpass, *bref, *bsha, *ref, *sha, *url)
 
-	args = append(args, "mixable/bios", "handler.Handle")
+	args = append(args, "mixable/bios", "runner")
 	cmd := exec.Command("docker", args...)
 	cmd.Env = []string{
 		fmt.Sprintf("USER=%s", *user),


### PR DESCRIPTION
Invoke the runner differently now that [mixable/bios](https://hub.docker.com/r/mixable/bios/) is build `FROM lambci/lambda:go1.x`